### PR TITLE
Add build tag when deploying

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: connect and pull
         run: ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd ${{ secrets.WORK_DIR }} &&
           docker pull getsky/weather-alert-bot:$RELEASE_VERSION &&
-          docker stop weather-alert-bta-telegrambot-$RELEASE_VERSION &&
+          docker rm -f weather-alert-bta-telegrambot-$RELEASE_VERSION || true &&
           docker run -d --name weather-alert-bta-telegrambot-$RELEASE_VERSION --restart=always
           -e BOT_TOKEN=${{ secrets.BOT_TOKEN }}
           -e TELEGRAM_CHAT_ID=${{ secrets.TELEGRAM_CHAT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
 
   deploy:
     needs: [ build_and_push ]
-    if: github.ref == 'refs/heads/main'
     name: deploy image
     env:
       RELEASE_VERSION: ${{ needs.build_and_push.outputs.RELEASE_VERSION }}
@@ -70,9 +69,8 @@ jobs:
       - name: connect and pull
         run: ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd ${{ secrets.WORK_DIR }} &&
           docker pull getsky/weather-alert-bot:$RELEASE_VERSION &&
-          docker stop weather-alert-bta-telegrambot &&
-          docker container rm weather-alert-bta-telegrambot &&
-          docker run -d --name weather-alert-bta-telegrambot --restart=always
+          docker stop weather-alert-bta-telegrambot-$RELEASE_VERSION &&
+          docker run -d --name weather-alert-bta-telegrambot-$RELEASE_VERSION --restart=always
           -e BOT_TOKEN=${{ secrets.BOT_TOKEN }}
           -e TELEGRAM_CHAT_ID=${{ secrets.TELEGRAM_CHAT_ID }}
           -e WEATHER_URL=${{ vars.WEATHER_URL }}
@@ -80,7 +78,7 @@ jobs:
           -e WIND_THRESHOLD=${{ vars.WIND_THRESHOLD }}
           -e POLL_INTERVAL=${{ vars.POLL_INTERVAL }}
           -e DELAY_TIME_IN_MINUTES=${{ vars.DELAY_TIME_IN_MINUTES }}
-          getsky/weather-alert-bot &&
+          getsky/weather-alert-bot:$RELEASE_VERSION &&
           exit"
 
       - name: cleanup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
 
   deploy:
     needs: [ build_and_push ]
+    if: github.ref == 'refs/heads/main'
     name: deploy image
     env:
       RELEASE_VERSION: ${{ needs.build_and_push.outputs.RELEASE_VERSION }}


### PR DESCRIPTION
## Why it’s needed
To ensure correct automatic service deployment.

## What was done
1. A tag has been added to deploy the newly built assembly to the server.
2. Added error suppression when deleting a container if it does not exist.