### PR TITLE
Manual deploy on server with separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
       - name: Test
         run: go test -v ./...
 
-  setup:
+  build-dev:
     needs: [ test ]
+    environment: develop
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
-    outputs:
-      RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -36,12 +36,6 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-  build-dev:
-    needs: [ setup ]
-    environment: develop
-    if: github.ref != 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -52,11 +46,20 @@ jobs:
           tags: ${{ vars.DEPLOY_REGISTRY_USERNAME }}/${{ vars.DEPLOY_IMAGE_NAME }}:${{ vars.DEPLOY_IMAGE_TAG }}
 
   build-prod:
-    needs: [ setup ]
+    needs: [ test ]
     environment: production
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DEPLOY_REGISTRY_USERNAME }}
+          password: ${{ secrets.DEPLOY_DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,23 +36,15 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Set the release version
-        id: release-version
-        run: |
-          release_version=$(echo "${{ github.ref }}" | sed 's|refs/heads/||;s|/|_|g')
-          echo "Building release version $release_version"
-          echo "RELEASE_VERSION=$release_version" >> $GITHUB_OUTPUT
-        shell: bash
-
   build-dev:
     needs: [ setup ]
     environment: develop
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -65,6 +57,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,12 @@ jobs:
           push: true
           tags: getsky/weather-alert-bot:${{ steps.release-version.outputs.RELEASE_VERSION }}
 
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: getsky/weather-alert-bot:dev
+
   deploy:
     needs: [ build_and_push ]
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Test
         run: go test -v ./...
 
-  build_and_push:
+  setup:
     needs: [ test ]
     runs-on: ubuntu-latest
     outputs:
@@ -47,47 +47,26 @@ jobs:
           echo "RELEASE_VERSION=$release_version" >> $GITHUB_OUTPUT
         shell: bash
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          tags: getsky/weather-alert-bot:${{ steps.release-version.outputs.RELEASE_VERSION }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          tags: getsky/weather-alert-bot:dev
-
-  deploy:
-    needs: [ build_and_push ]
-    if: github.ref == 'refs/heads/main'
-    name: deploy image
-    environment: production
-    env:
-      RELEASE_VERSION: ${{ needs.build_and_push.outputs.RELEASE_VERSION }}
+  build-dev:
+    needs: [ setup ]
+    environment: develop
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - name: install ssh keys
-        run: |
-          install -m 600 -D /dev/null ~/.ssh/id_rsa
-          echo "${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-          ssh-keyscan -H ${{ secrets.DEPLOY_SSH_HOST }} > ~/.ssh/known_hosts
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ vars.DEPLOY_REGISTRY_USERNAME }}/${{ vars.DEPLOY_IMAGE_NAME }}:${{ vars.DEPLOY_IMAGE_TAG }}
 
-      - name: connect and pull
-        run: ssh ${{ secrets.DEPLOY_SSH_USER }}@${{ secrets.DEPLOY_SSH_HOST }} "cd ${{ secrets.DEPLOY_WORK_DIR }} &&
-          docker pull getsky/weather-alert-bot:$RELEASE_VERSION &&
-          docker rm -f weather-alert-bta-telegrambot-$RELEASE_VERSION || true &&
-          docker run -d --name weather-alert-bta-telegrambot-$RELEASE_VERSION --restart=always
-          -e BOT_TOKEN=${{ secrets.APP_BOT_TOKEN }}
-          -e TELEGRAM_CHAT_ID=${{ secrets.APP_TELEGRAM_CHAT_ID }}
-          -e WEATHER_URL=${{ vars.APP_WEATHER_URL }}
-          -e CHART_WEATHER_URL=${{ vars.APP_CHART_WEATHER_URL }}
-          -e WIND_THRESHOLD=${{ vars.APP_WIND_THRESHOLD }}
-          -e POLL_INTERVAL=${{ vars.APP_POLL_INTERVAL }}
-          -e DELAY_TIME_IN_MINUTES=${{ vars.APP_DELAY_TIME_IN_MINUTES }}
-          getsky/weather-alert-bot:$RELEASE_VERSION &&
-          exit"
-
-      - name: cleanup
-        run: rm -rf ~/.ssh
+  build-prod:
+    needs: [ setup ]
+    environment: production
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ vars.DEPLOY_REGISTRY_USERNAME }}/${{ vars.DEPLOY_IMAGE_NAME }}:${{ vars.DEPLOY_IMAGE_TAG }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build & Deploy
 
 on:
   push:
-    branches: [ "main", "feat/ci_**",  "refactor/ci_**", "fix/ci_**" ]
+    branches: [ "main", "feat/**",  "refactor/**", "fix/**" ]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ vars.DEPLOY_REGISTRY_USERNAME }}
+          password: ${{ secrets.DEPLOY_DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -57,6 +57,7 @@ jobs:
     needs: [ build_and_push ]
     if: github.ref == 'refs/heads/main'
     name: deploy image
+    environment: production
     env:
       RELEASE_VERSION: ${{ needs.build_and_push.outputs.RELEASE_VERSION }}
     runs-on: ubuntu-latest
@@ -64,21 +65,21 @@ jobs:
       - name: install ssh keys
         run: |
           install -m 600 -D /dev/null ~/.ssh/id_rsa
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-          ssh-keyscan -H ${{ secrets.SSH_HOST }} > ~/.ssh/known_hosts
+          echo "${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.DEPLOY_SSH_HOST }} > ~/.ssh/known_hosts
 
       - name: connect and pull
-        run: ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd ${{ secrets.WORK_DIR }} &&
+        run: ssh ${{ secrets.DEPLOY_SSH_USER }}@${{ secrets.DEPLOY_SSH_HOST }} "cd ${{ secrets.DEPLOY_WORK_DIR }} &&
           docker pull getsky/weather-alert-bot:$RELEASE_VERSION &&
           docker rm -f weather-alert-bta-telegrambot-$RELEASE_VERSION || true &&
           docker run -d --name weather-alert-bta-telegrambot-$RELEASE_VERSION --restart=always
-          -e BOT_TOKEN=${{ secrets.BOT_TOKEN }}
-          -e TELEGRAM_CHAT_ID=${{ secrets.TELEGRAM_CHAT_ID }}
-          -e WEATHER_URL=${{ vars.WEATHER_URL }}
-          -e CHART_WEATHER_URL=${{ vars.CHART_WEATHER_URL }}
-          -e WIND_THRESHOLD=${{ vars.WIND_THRESHOLD }}
-          -e POLL_INTERVAL=${{ vars.POLL_INTERVAL }}
-          -e DELAY_TIME_IN_MINUTES=${{ vars.DELAY_TIME_IN_MINUTES }}
+          -e BOT_TOKEN=${{ secrets.APP_BOT_TOKEN }}
+          -e TELEGRAM_CHAT_ID=${{ secrets.APP_TELEGRAM_CHAT_ID }}
+          -e WEATHER_URL=${{ vars.APP_WEATHER_URL }}
+          -e CHART_WEATHER_URL=${{ vars.APP_CHART_WEATHER_URL }}
+          -e WIND_THRESHOLD=${{ vars.APP_WIND_THRESHOLD }}
+          -e POLL_INTERVAL=${{ vars.APP_POLL_INTERVAL }}
+          -e DELAY_TIME_IN_MINUTES=${{ vars.APP_DELAY_TIME_IN_MINUTES }}
           getsky/weather-alert-bot:$RELEASE_VERSION &&
           exit"
 

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -11,6 +11,23 @@ jobs:
     runs-on: ubuntu-latest
     environment: develop
     steps:
-      - name: deploy
+      - name: install ssh keys
         run: |
-          echo "Image: ${{ vars.IMAGE_NAME }}:${{ vars.IMAGE_TAG }}"
+          install -m 600 -D /dev/null ~/.ssh/id_rsa
+          echo "${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.DEPLOY_SSH_HOST }} > ~/.ssh/known_hosts
+
+      - name: run service
+        run: ssh ${{ secrets.DEPLOY_SSH_USER }}@${{ secrets.DEPLOY_SSH_HOST }} "cd ${{ secrets.DEPLOY_WORK_DIR }} &&
+          docker pull ${{ vars.DEPLOY_REGISTRY_USERNAME }}/${{ vars.DEPLOY_IMAGE_NAME }}:${{ vars.DEPLOY_IMAGE_TAG }} &&
+          docker rm -f ${{ vars.DEPLOY_IMAGE_NAME }}-${{ vars.DEPLOY_IMAGE_TAG }} || true &&
+          docker run -d --name ${{ vars.DEPLOY_IMAGE_NAME }}-${{ vars.DEPLOY_IMAGE_TAG }} --restart=always
+          -e BOT_TOKEN=${{ secrets.APP_BOT_TOKEN }}
+          -e TELEGRAM_CHAT_ID=${{ secrets.APP_TELEGRAM_CHAT_ID }}
+          -e WEATHER_URL=${{ vars.APP_WEATHER_URL }}
+          -e CHART_WEATHER_URL=${{ vars.APP_CHART_WEATHER_URL }}
+          -e WIND_THRESHOLD=${{ vars.APP_WIND_THRESHOLD }}
+          -e POLL_INTERVAL=${{ vars.APP_POLL_INTERVAL }}
+          -e DELAY_TIME_IN_MINUTES=${{ vars.APP_DELAY_TIME_IN_MINUTES }}
+          ${{ vars.DEPLOY_REGISTRY_USERNAME }}/${{ vars.DEPLOY_IMAGE_NAME }}:${{ vars.DEPLOY_IMAGE_TAG }} &&
+          exit"

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   deployment:
     runs-on: ubuntu-latest
+    environment: ${{ vars.ENVIRONMENT_STAGE }}
     steps:
       - name: deploy
         run: |

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -1,6 +1,9 @@
-name: Deploy on server
+name: Deployment on Develop
 
 on:
+  push:
+    branches-ignore:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   deployment:
     runs-on: ubuntu-latest
-    environment: production
     steps:
       - name: deploy
         run: |

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   deployment:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref_name == 'main' && 'production' || 'dev' }}
+    environment: ${{ github.ref_name == 'main' && 'production' || 'develop' }}
     steps:
       - name: install ssh keys
         run: |

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -3,16 +3,11 @@ name: Deploy on server
 on:
   workflow_dispatch:
 
-env:
-  # Setting an environment variable with the value of a configuration variable
-  env_var: ${{ vars.ENV_CONTEXT_VAR }}
-
 jobs:
   deployment:
     runs-on: ubuntu-latest
-    environment: ${{ vars.ENVIRONMENT_STAGE }}
+    environment: production
     steps:
       - name: deploy
         run: |
-          echo "ENVIRONMENT_STAGE: ${{ vars.ENVIRONMENT_STAGE }}"
-          echo "Deploy run and say: ${{ vars.TEST_ENV }}"
+          echo "Image: ${{ vars.IMAGE_NAME }}:${{ vars.TAG }}"

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -10,5 +10,5 @@ jobs:
     steps:
       - name: deploy
         run: |
-          echo "Deploy run and say:"
-          echo ${{ vars.TEST_ENV }}
+          echo "ENVIRONMENT_STAGE: ${{ vars.ENVIRONMENT_STAGE }}"
+          echo "Deploy run and say: ${{ vars.TEST_ENV }}"

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -1,10 +1,12 @@
-  on:
-    workflow_dispatch:
+name: Deploy on server
 
-  jobs:
-    deployment:
-      runs-on: ubuntu-latest
-      environment: production
-      steps:
-        - name: deploy
-          run: echo "Deploy run"
+on:
+  workflow_dispatch:
+
+jobs:
+  deployment:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: deploy
+        run: echo "Deploy run"

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -9,5 +9,5 @@ jobs:
     steps:
       - name: deploy
         run: |
-          echo "Deploy run"
+          echo "Deploy run and say:"
           echo ${{ vars.TEST_ENV }}

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -1,9 +1,6 @@
 name: Deployment on Develop
 
 on:
-  push:
-    branches-ignore:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - name: deploy
         run: |
-          echo "Image: ${{ vars.IMAGE_NAME }}:${{ vars.TAG }}"
+          echo "Image: ${{ vars.IMAGE_NAME }}:${{ vars.IMAGE_TAG }}"

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -9,4 +9,6 @@ jobs:
     environment: production
     steps:
       - name: deploy
-        run: echo "Deploy run"
+        run: |
+          echo "Deploy run"
+          echo ${{ vars.TEST_ENV }}

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -1,4 +1,4 @@
-name: Deployment on Develop
+name: Manual deployment
 
 on:
   workflow_dispatch:
@@ -6,7 +6,7 @@ on:
 jobs:
   deployment:
     runs-on: ubuntu-latest
-    environment: develop
+    environment: ${{ github.ref_name == 'main' && 'production' || 'dev' }}
     steps:
       - name: install ssh keys
         run: |

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   deployment:
     runs-on: ubuntu-latest
-    environment: production
+    environment: develop
     steps:
       - name: deploy
         run: |

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -3,6 +3,10 @@ name: Deploy on server
 on:
   workflow_dispatch:
 
+env:
+  # Setting an environment variable with the value of a configuration variable
+  env_var: ${{ vars.ENV_CONTEXT_VAR }}
+
 jobs:
   deployment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why it’s needed
These changes are intended to simplify application deployment and debugging of the new functionality.

## What was done
1. Two environments are allocated: `production` and `develop`. Depending on the environment settings, the application is installed on different machines and written to different chats.
2. Deployment is done only manually through a special workflow `Manual deployment`.
3. If the server failed to download a new wind chart, do not block the notification.
4. Assembly is carried out for branches: `main`, `feat/*`, `refactor/*` and `fix/*`.