### PR TITLE
Move the logic for loading the weather chart to a separate service

### DIFF
--- a/chart_service.go
+++ b/chart_service.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+const tmpFileName = "chart.png"
+
+type chartService struct {
+	chartURL string
+	tmpPath  string
+}
+
+func NewChartService(
+	chartWeatherURL string,
+) ChartService {
+	return &chartService{
+		chartURL: chartWeatherURL,
+	}
+}
+
+func (c chartService) GetUpdatedChart() (Chart, error) {
+	chart, err := c.downloadChart()
+	if err != nil {
+		return Chart{}, fmt.Errorf("downloadChart → %s", err)
+	}
+	return chart, nil
+}
+
+// downloadChart
+// Upload the image to ourselves, because if send it to a direct URI, Telegram will not allow us to reload it later.
+func (c chartService) downloadChart() (Chart, error) {
+	resp, err := http.Get(c.chartURL)
+	if err != nil {
+		return Chart{}, fmt.Errorf("failed to download image: %v", err)
+	}
+
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return Chart{}, fmt.Errorf("unexpected HTTP status: %s", resp.Status)
+	}
+
+	file, err := os.Create(tmpFileName)
+	if err != nil {
+		return Chart{}, fmt.Errorf("failed to create file: %v", err)
+	}
+
+	defer func(file *os.File) {
+		_ = file.Close()
+	}(file)
+
+	_, err = io.Copy(file, resp.Body)
+	if err != nil {
+		return Chart{}, fmt.Errorf("failed to save image: %v", err)
+	}
+
+	return Chart{
+		Path:     tmpFileName,
+		CreateAt: time.Now(),
+	}, nil
+}


### PR DESCRIPTION
## Why it’s needed
1. This code makes it easier to further improve the bot's logic.
2. The chart is updated stably every few minutes.

## What was done
1. PNG downloading has been moved to a separate service.
3. It turned out that the png with the weather chart is updated only if someone calls another URL with a CGI script. Because of this, the chart was not updated in the chat all night. I set the target URL that leads to CGI.
4. Image loading no longer relies on the `Last-Modified` header, as the new target link does not have one.