### PR TITLE
Add check that navigational twilight has come and gone

### DIFF
--- a/cmd/application/main.go
+++ b/cmd/application/main.go
@@ -40,6 +40,7 @@ var (
 var client *http.Client
 var chartSrv ChartService
 var notifySrv NotifyService
+var twilightSrv TwilightService
 
 var (
 	lastModified      string
@@ -114,12 +115,15 @@ func main() {
 		fmt.Printf("Failed to initialize bot: %v\n", err)
 		os.Exit(1)
 	}
-
 	chartSrv = NewChartService(chartWeatherURL)
 	notifySrv = NewTelegramNotifyService(bot, telegramChat)
+	twilightSrv = NewNauticalTwilightService()
 
 	for {
-		checkWeather()
+		isTwilight, _ := twilightSrv.CheckNauticalTwilight()
+		if isTwilight {
+			checkWeather()
+		}
 		time.Sleep(pollInterval)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/GetSky/WeatherAlertBTA
 
 go 1.20
 
-require github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
+require (
+	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
+	github.com/sixdouglas/suncalc v0.0.0-20230303054245-f8bc8c69d09e
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
 github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
+github.com/sixdouglas/suncalc v0.0.0-20230303054245-f8bc8c69d09e h1:I/wuFDXuedEYC+iSy0jzO7adpH5n+mnblZpozttUP1Y=
+github.com/sixdouglas/suncalc v0.0.0-20230303054245-f8bc8c69d09e/go.mod h1:IxOCrQX3pAL52wPiWuamnWxGcuyWANPyQfwcRb0iDqc=

--- a/internal/application/interfaces.go
+++ b/internal/application/interfaces.go
@@ -10,6 +10,10 @@ type NotifyService interface {
 	UpdateLastChart(chart Chart, text string) error
 }
 
+type TwilightService interface {
+	CheckNauticalTwilight() (bool, error)
+}
+
 type ChartService interface {
 	GetUpdatedChart() (Chart, error)
 }

--- a/internal/infrastructure/nautical_service.go
+++ b/internal/infrastructure/nautical_service.go
@@ -19,8 +19,9 @@ func NewNauticalTwilightService() application.TwilightService {
 
 func (n *nauticalTwilightService) CheckNauticalTwilight() (bool, error) {
 	now := time.Now()
-	start, _ := n.calc(now, suncalc.NauticalDusk)
-	end, _ := n.calc(now.AddDate(0, 0, 1), suncalc.NauticalDawn)
+	ref := now.Add(-12 * time.Hour) // Using a reference date to correct premature date translation when reaching 00:00
+	start, _ := n.calc(ref, suncalc.NauticalDusk)
+	end, _ := n.calc(ref.AddDate(0, 0, 1), suncalc.NauticalDawn)
 
 	return now.After(start) && now.Before(end), nil
 }

--- a/internal/infrastructure/nautical_service.go
+++ b/internal/infrastructure/nautical_service.go
@@ -1,0 +1,41 @@
+package infrastructure
+
+import (
+	"github.com/GetSky/WeatherAlertBTA/internal/application"
+	"github.com/sixdouglas/suncalc"
+	"time"
+)
+
+var (
+	lat, long = 43.649329, 41.426829 // BTA coordinates
+)
+
+type nauticalTwilightService struct {
+}
+
+func NewNauticalTwilightService() application.TwilightService {
+	return &nauticalTwilightService{}
+}
+
+func (n *nauticalTwilightService) CheckNauticalTwilight() (bool, error) {
+	now := time.Now()
+	start, _ := n.calc(now, suncalc.NauticalDusk)
+	end, _ := n.calc(now.AddDate(0, 0, 1), suncalc.NauticalDawn)
+
+	return now.After(start) && now.Before(end), nil
+}
+
+func (n *nauticalTwilightService) calc(date time.Time, name suncalc.DayTimeName) (time.Time, error) {
+	times := suncalc.GetTimes(date, lat, long)
+	date = time.Date(
+		date.Year(),
+		date.Month(),
+		date.Day(),
+		times[name].Value.Hour(),
+		times[name].Value.Minute(),
+		0,
+		0,
+		time.UTC,
+	)
+	return date, nil
+}


### PR DESCRIPTION
## Why it’s needed
This code adds a check for the start and end of nautical twilight. This prevents weather notifications from being sent during the day.

## What was done
1. Added `sixdouglas/suncalc` library as a dependency.
2. The logic for checking the onset and end of navigational twilight has been implemented.