### PR TITLE
Add time reserve before dusk

### DIFF
--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -26,5 +26,6 @@ jobs:
           -e WIND_THRESHOLD=${{ vars.APP_WIND_THRESHOLD }}
           -e POLL_INTERVAL=${{ vars.APP_POLL_INTERVAL }}
           -e DELAY_TIME_IN_MINUTES=${{ vars.APP_DELAY_TIME_IN_MINUTES }}
+          -e RESERVE_TIME_BEFORE_DUSK_IN_MINUTES=${{ vars.APP_RESERVE_TIME_BEFORE_DUSK_IN_MINUTES }}
           ${{ vars.DEPLOY_REGISTRY_USERNAME }}/${{ vars.DEPLOY_IMAGE_NAME }}:${{ vars.DEPLOY_IMAGE_TAG }} &&
           exit"

--- a/cmd/application/main.go
+++ b/cmd/application/main.go
@@ -31,13 +31,14 @@ Wind Speed: %.1f m/s
 Wind speed is now below the threshold.`
 
 var (
-	url             string
-	botToken        string
-	telegramChat    string
-	windThreshold   float64
-	DelayTime       time.Duration
-	pollInterval    time.Duration
-	chartWeatherURL string
+	url                   string
+	botToken              string
+	telegramChat          string
+	windThreshold         float64
+	DelayTime             time.Duration
+	pollInterval          time.Duration
+	chartWeatherURL       string
+	timeReserveBeforeDusk time.Duration
 )
 
 var client *http.Client
@@ -110,6 +111,17 @@ func init() {
 			os.Exit(1)
 		}
 	}
+
+	timeReserveBeforeDuskStr := os.Getenv("RESERVE_TIME_BEFORE_DUSK_IN_MINUTES")
+	if timeReserveBeforeDuskStr == "" {
+		timeReserveBeforeDusk = 120 * time.Minute
+	} else {
+		timeReserveBeforeDusk, err = time.ParseDuration(timeReserveBeforeDuskStr)
+		if err != nil {
+			fmt.Printf("Failed to parse RESERVE_TIME_BEFORE_DUSK_IN_MINUTES: %v\n", err)
+			os.Exit(1)
+		}
+	}
 }
 
 func main() {
@@ -120,7 +132,7 @@ func main() {
 	}
 	chartSrv = NewChartService(chartWeatherURL)
 	notifySrv = NewTelegramNotifyService(bot, telegramChat)
-	twilightSrv = NewTwilightService()
+	twilightSrv = NewTwilightService(timeReserveBeforeDusk)
 
 	for {
 		isTwilight, _ := twilightSrv.CheckNauticalTwilight()

--- a/internal/infrastructure/twilight_service.go
+++ b/internal/infrastructure/twilight_service.go
@@ -14,16 +14,20 @@ var (
 )
 
 type twilightService struct {
+	beforeDusk time.Duration
 }
 
-func NewTwilightService() application.TwilightService {
-	return &twilightService{}
+func NewTwilightService(beforeDusk time.Duration) application.TwilightService {
+	return &twilightService{
+		beforeDusk: beforeDusk,
+	}
 }
 
 func (n *twilightService) CheckNauticalTwilight() (bool, error) {
 	now := time.Now()
 	ref := now.Add(-12 * time.Hour) // Using a reference date to correct premature date translation when reaching 00:00
 	start, _ := n.calc(ref, suncalc.NauticalDusk)
+	start = start.Add(-n.beforeDusk)
 	end, _ := n.calc(ref.AddDate(0, 0, 1), suncalc.NauticalDawn)
 
 	return now.After(start) && now.Before(end), nil


### PR DESCRIPTION
## Why it’s needed
These changes allow wind tracking to be started before nautical twilight begins.
This makes it easier to prepare for launching telescopes.

## What was done
1. Added `RESERVE_TIME_BEFORE_DUSK_IN_MINUTES` to environment var.
2. Increased the range of this variable's value when checking for dusk.