### PR TITLE
Rename twilight service

### DIFF
--- a/cmd/application/main.go
+++ b/cmd/application/main.go
@@ -44,7 +44,7 @@ var (
 var client *http.Client
 var chartSrv ChartService
 var notifySrv NotifyService
-var twilightSrv TwilightService
+var twilightSrv ScheduleService
 
 var (
 	lastModified      string
@@ -135,7 +135,7 @@ func main() {
 	twilightSrv = NewTwilightService(timeReserveBeforeDusk)
 
 	for {
-		isTwilight, _ := twilightSrv.CheckNauticalTwilight()
+		isTwilight, _ := twilightSrv.IsWorkNow()
 		if isTwilight {
 			checkWeather()
 		}

--- a/internal/application/interfaces.go
+++ b/internal/application/interfaces.go
@@ -13,8 +13,8 @@ type NotifyService interface {
 	UpdateLastChart(chart Chart, text string) error
 }
 
-type TwilightService interface {
-	CheckNauticalTwilight() (bool, error)
+type ScheduleService interface {
+	IsWorkNow() (bool, error)
 }
 
 type ChartService interface {

--- a/internal/infrastructure/schedule_service.go
+++ b/internal/infrastructure/schedule_service.go
@@ -17,13 +17,13 @@ type twilightService struct {
 	beforeDusk time.Duration
 }
 
-func NewTwilightService(beforeDusk time.Duration) application.TwilightService {
+func NewTwilightService(beforeDusk time.Duration) application.ScheduleService {
 	return &twilightService{
 		beforeDusk: beforeDusk,
 	}
 }
 
-func (n *twilightService) CheckNauticalTwilight() (bool, error) {
+func (n *twilightService) IsWorkNow() (bool, error) {
 	now := time.Now()
 	ref := now.Add(-12 * time.Hour) // Using a reference date to correct premature date translation when reaching 00:00
 	start, _ := n.calc(ref, suncalc.NauticalDusk)


### PR DESCRIPTION
## Why it’s needed
With the addition of time reserve, this service now does more than just detect the start and end of twilight.

## What was done
1. Rename `TwilightService` serive to `ScheduleService`