### PR TITLE
Added start and end massage.

### DIFF
--- a/cmd/application/main.go
+++ b/cmd/application/main.go
@@ -34,7 +34,7 @@ var cnf *config.Conf
 var client *http.Client
 var chartSrv ChartService
 var notifySrv NotifyService
-var twilightSrv ScheduleService
+var scheduleSrv ScheduleService
 
 var (
 	lastModified      string
@@ -60,10 +60,10 @@ func main() {
 	}
 	chartSrv = NewChartService(cnf.ChartWeatherUrl)
 	notifySrv = NewTelegramNotifyService(bot, cnf.TelegramChat)
-	twilightSrv = NewTwilightService(cnf.TimeReserveBeforeDusk)
+	scheduleSrv = NewScheduleService(cnf.TimeReserveBeforeDusk)
 
 	for {
-		isWorkTime, _ := twilightSrv.IsWorkNow()
+		isWorkTime, _ := scheduleSrv.IsWorkNow()
 		if isWorkTime {
 			checkWeather()
 		}

--- a/internal/application/interfaces.go
+++ b/internal/application/interfaces.go
@@ -13,6 +13,7 @@ type NotifyService interface {
 
 type ScheduleService interface {
 	IsWorkNow() (bool, error)
+	GetNautical(date time.Time) (dusk time.Time, dawn time.Time, err error)
 }
 
 type ChartService interface {

--- a/internal/application/interfaces.go
+++ b/internal/application/interfaces.go
@@ -6,8 +6,8 @@ package application
 import "time"
 
 type NotifyService interface {
-	SendWorkStarted(chart Chart, data Weather) error
-	SendWorkEnded(chart Chart, data Weather) error
+	SendWorkStarted(dusk time.Time, dawn time.Time) error
+	SendWorkEnded() error
 	SendUpdate(chart Chart, data Weather) error
 }
 

--- a/internal/infrastructure/schedule_service.go
+++ b/internal/infrastructure/schedule_service.go
@@ -4,37 +4,59 @@
 package infrastructure
 
 import (
+	"fmt"
 	"github.com/GetSky/WeatherAlertBTA/internal/application"
 	"github.com/sixdouglas/suncalc"
 	"time"
 )
 
 var (
-	lat, long = 43.649329, 41.426829 // BTA coordinates
+	lat, long, height = 43.649329, 41.426829, 2070.0 // BTA coordinates
 )
 
-type twilightService struct {
+type scheduleService struct {
 	beforeDusk time.Duration
 }
 
-func NewTwilightService(beforeDusk time.Duration) application.ScheduleService {
-	return &twilightService{
+func NewScheduleService(beforeDusk time.Duration) application.ScheduleService {
+	return &scheduleService{
 		beforeDusk: beforeDusk,
 	}
 }
 
-func (n *twilightService) IsWorkNow() (bool, error) {
+func (n *scheduleService) IsWorkNow() (bool, error) {
 	now := time.Now()
-	ref := now.Add(-12 * time.Hour) // Using a reference date to correct premature date translation when reaching 00:00
-	start, _ := n.calc(ref, suncalc.NauticalDusk)
+	start, end, err := n.GetNautical(now)
+	if err != nil {
+		return false, err
+	}
 	start = start.Add(-n.beforeDusk)
-	end, _ := n.calc(ref.AddDate(0, 0, 1), suncalc.NauticalDawn)
 
 	return now.After(start) && now.Before(end), nil
 }
 
-func (n *twilightService) calc(date time.Time, name suncalc.DayTimeName) (time.Time, error) {
-	times := suncalc.GetTimes(date, lat, long)
+func (n *scheduleService) GetNautical(now time.Time) (dusk time.Time, dawn time.Time, err error) {
+	err = nil
+	ref := now.Add(-12 * time.Hour) // Using a reference date to correct premature date translation when reaching 00:00
+	dusk, err = n.calc(ref, suncalc.NauticalDusk)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("scheduleService → %s", err)
+	}
+
+	dawn, err = n.calc(ref.AddDate(0, 0, 1), suncalc.NauticalDawn)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("scheduleService → %s", err)
+	}
+
+	return dusk, dawn, err
+}
+
+func (n *scheduleService) calc(date time.Time, name suncalc.DayTimeName) (time.Time, error) {
+	times := suncalc.GetTimesWithObserver(
+		date,
+		suncalc.Observer{Latitude: lat, Longitude: long, Height: height, Location: time.UTC},
+	)
+
 	date = time.Date(
 		date.Year(),
 		date.Month(),


### PR DESCRIPTION
## Why it’s needed
This code adds sending of messages about the start and end of observations. This allows you to better understand the current state of observations.
![image](https://github.com/user-attachments/assets/43cf270c-07dd-4fba-ac58-7ba440489ce6)
![image](https://github.com/user-attachments/assets/bbdf24c9-74c9-4950-9d2e-ea7a51c8c2a9)


## What was done
1. Added method for obtaining the onset of nautical twilight.
2. Added start and end massage.
3. Renamed Twilight Service to Schedule Service.