### PR TITLE
Add weather service

### DIFF
--- a/cmd/application/main.go
+++ b/cmd/application/main.go
@@ -4,48 +4,29 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"github.com/GetSky/WeatherAlertBTA/config"
 	. "github.com/GetSky/WeatherAlertBTA/internal/application"
 	. "github.com/GetSky/WeatherAlertBTA/internal/infrastructure"
 	"github.com/go-telegram-bot-api/telegram-bot-api/v5"
-	"net/http"
 	"os"
-	"strconv"
-	"strings"
 	"time"
 )
 
-var alertTemplate = `🚨 *Wind Alert* %s
-
-Temperature: *%s°C*
-Wind Speed: *%.1f m/s*
-`
-
-var windTemplate = `ℹ️ *Wind Update* %s
-
-Temperature: *%s°C*
-Wind Speed: *%.1f m/s*
-_Wind speed is now below the threshold._`
-
 var cnf *config.Conf
 
-var client *http.Client
+var weatherSrv WeatherService
 var chartSrv ChartService
 var notifySrv NotifyService
 var scheduleSrv ScheduleService
 
 var (
-	lastModified      string
 	workActive        bool
 	windAlertActive   bool
 	lastWindAlertTime time.Time
 )
 
 func init() {
-	client = &http.Client{}
-
 	var err error
 	cnf, err = config.NewConf()
 	if err != nil {
@@ -60,6 +41,7 @@ func main() {
 		os.Exit(1)
 	}
 	chartSrv = NewChartService(cnf.ChartWeatherUrl)
+	weatherSrv = NewWeatherService(cnf.WeatherUrl)
 	notifySrv = NewTelegramNotifyService(bot, cnf.TelegramChat)
 	scheduleSrv = NewScheduleService(cnf.TimeReserveBeforeDusk)
 
@@ -94,121 +76,25 @@ func main() {
 	}
 }
 
-func GetLastUpdate(url string) (string, error) {
-	modifiedAt := ""
-	headReq, err := http.NewRequest("HEAD", url, nil)
-	if err != nil {
-		return modifiedAt, fmt.Errorf("Failed to create HEAD request: %v\n", err)
-	}
-
-	headResp, err := client.Do(headReq)
-	if err != nil {
-		return modifiedAt, fmt.Errorf("HEAD request failed: %v\n", err)
-	}
-	defer headResp.Body.Close()
-
-	if headResp.StatusCode != http.StatusOK {
-		return modifiedAt, fmt.Errorf("Unexpected HEAD response: %s\n", headResp.Status)
-	}
-
-	modifiedAt = headResp.Header.Get("Last-Modified")
-	return modifiedAt, nil
-}
-
 func checkWeather() {
-	// Checking for an updated file
-	modifiedAt, err := GetLastUpdate(cnf.WeatherUrl)
-	if err != nil {
-		fmt.Printf("Failed to check last update: %v\n", err)
-		return
-	}
-
 	chart, err := chartSrv.GetUpdatedChart()
 	if err != nil {
 		fmt.Printf("ChartService → %v\n", err)
 		return
 	}
 
-	/* ToDo: Return logic after transfer to weather data receiving service
-	err = notifySrv.UpdateLastChart(chart, "")
+	weather, err := weatherSrv.GetLatestWeather()
 	if err != nil {
-		fmt.Printf("Main → %v\n", err)
-	}
-	*/
-
-	if modifiedAt == lastModified {
-		fmt.Println("Data has not changed since last check.")
+		fmt.Printf("WeatherService → %v\n", err)
 		return
 	}
 
-	lastModified = modifiedAt
-
-	// Use Range header to fetch only the last 66 bytes (approximately one line)
-	req, err := http.NewRequest("GET", cnf.WeatherUrl, nil)
-	if err != nil {
-		fmt.Printf("Failed to create GET request: %v\n", err)
-		return
-	}
-	req.Header.Set("Range", "bytes=-66")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		fmt.Printf("Failed to fetch weather data: %v\n", err)
-		return
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusPartialContent {
-		fmt.Printf("Unexpected HTTP response: %s\n", resp.Status)
-		return
-	}
-
-	scanner := bufio.NewScanner(resp.Body)
-	scanner.Scan()
-	var lastLine = scanner.Text()
-
-	if lastLine == "" {
-		fmt.Println("No data available.")
-		return
-	}
-
-	fields := strings.Fields(lastLine)
-	if len(fields) < 9 {
-		fmt.Println("Malformed last line.")
-		return
-	}
-
-	windSpeed, err := strconv.ParseFloat(fields[7], 64)
-	if err != nil {
-		fmt.Printf("Error parsing wind speed: %v\n", err)
-		return
-	}
-
-	temp, err := strconv.ParseFloat(fields[3], 64)
-	if err != nil {
-		fmt.Printf("Error parsing temperature: %v\n", err)
-		return
-	}
-
-	timestamp := fmt.Sprintf("%s %s", fields[0], fields[1])
-	updateAt, err := time.Parse("02-Jan-2006 15:04:05", timestamp)
-	if err != nil {
-		fmt.Printf("Error parsing date time: %v\n", err)
-		return
-	}
-
-	data := Weather{
-		UpdateAt:    updateAt,
-		Temperature: temp,
-		WindSpeed:   windSpeed,
-	}
-
-	if windSpeed >= cnf.WindThreshold {
-		data.Hazardous = true
+	if weather.WindSpeed >= cnf.WindThreshold {
+		weather.Hazardous = true
 		lastWindAlertTime = time.Now()
 		windAlertActive = true
 
-		err = notifySrv.SendUpdate(chart, data)
+		err = notifySrv.SendUpdate(chart, weather)
 		if err != nil {
 			fmt.Printf("Main → %v\n", err)
 			return
@@ -220,9 +106,8 @@ func checkWeather() {
 		if windAlertActive {
 			duration := time.Since(lastWindAlertTime)
 			if duration > cnf.DelayTime {
-
-				data.Hazardous = false
-				err = notifySrv.SendUpdate(chart, data)
+				weather.Hazardous = false
+				err = notifySrv.SendUpdate(chart, weather)
 				if err != nil {
 					fmt.Printf("Main → %v\n", err)
 					return
@@ -234,8 +119,8 @@ func checkWeather() {
 				fmt.Println("The wind speed is below the threshold, but the time has not come to cancel the alert.")
 			}
 		} else {
-			data.Hazardous = false
-			err = notifySrv.SendUpdate(chart, data)
+			weather.Hazardous = false
+			err = notifySrv.SendUpdate(chart, weather)
 			if err != nil {
 				fmt.Printf("Main → %v\n", err)
 				return

--- a/internal/application/interfaces.go
+++ b/internal/application/interfaces.go
@@ -20,6 +20,10 @@ type ChartService interface {
 	GetUpdatedChart() (Chart, error)
 }
 
+type WeatherService interface {
+	GetLatestWeather() (Weather, error)
+}
+
 type Chart struct {
 	Path     string
 	CreateAt time.Time

--- a/internal/infrastructure/weather_service.go
+++ b/internal/infrastructure/weather_service.go
@@ -1,0 +1,120 @@
+// Copyright 2024 Alexander Getmansky <alex@getsky.tech>
+// Licensed under the Apache License, Version 2.0
+
+package infrastructure
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/GetSky/WeatherAlertBTA/internal/application"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type weatherService struct {
+	http         http.Client
+	WeatherUrl   string
+	lastModified string
+	current      application.Weather
+}
+
+func NewWeatherService(url string) application.WeatherService {
+	return &weatherService{
+		WeatherUrl: url,
+	}
+}
+
+func (w *weatherService) GetLatestWeather() (weather application.Weather, err error) {
+	// Checking for an updated file
+	modifiedAt, err := w.getLastUpdate(w.WeatherUrl)
+	if err != nil {
+		return weather, fmt.Errorf("Failed to check last update: %v\n", err)
+	}
+
+	if modifiedAt == w.lastModified {
+		return w.current, nil
+	}
+	w.lastModified = modifiedAt
+
+	req, err := http.NewRequest("GET", w.WeatherUrl, nil)
+	if err != nil {
+
+		return weather, fmt.Errorf("Failed to create GET request: %v\n", err)
+	}
+	req.Header.Set("Range", "bytes=-66")
+
+	resp, err := w.http.Do(req)
+	if err != nil {
+		return weather, fmt.Errorf("Failed to fetch weather data: %v\n", err)
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
+
+	if resp.StatusCode != http.StatusPartialContent {
+		return weather, fmt.Errorf("Unexpected HTTP response: %s\n", resp.Status)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Scan()
+	var lastLine = scanner.Text()
+
+	if lastLine == "" {
+		return weather, fmt.Errorf("no data available")
+	}
+
+	fields := strings.Fields(lastLine)
+	if len(fields) < 9 {
+		return weather, fmt.Errorf("malformed last line")
+	}
+
+	windSpeed, err := strconv.ParseFloat(fields[7], 64)
+	if err != nil {
+		return weather, fmt.Errorf("Error parsing wind speed: %v\n", err)
+	}
+
+	temp, err := strconv.ParseFloat(fields[3], 64)
+	if err != nil {
+		return weather, fmt.Errorf("Error parsing temperature: %v\n", err)
+	}
+
+	timestamp := fmt.Sprintf("%s %s", fields[0], fields[1])
+	updateAt, err := time.Parse("02-Jan-2006 15:04:05", timestamp)
+	if err != nil {
+		return weather, fmt.Errorf("Error parsing date time: %v\n", err)
+	}
+
+	w.current = application.Weather{
+		UpdateAt:    updateAt,
+		Temperature: temp,
+		WindSpeed:   windSpeed,
+	}
+
+	return w.current, nil
+}
+
+func (w *weatherService) getLastUpdate(url string) (string, error) {
+	modifiedAt := ""
+	headReq, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return modifiedAt, fmt.Errorf("Failed to create HEAD request: %v\n", err)
+	}
+
+	headResp, err := w.http.Do(headReq)
+	if err != nil {
+		return modifiedAt, fmt.Errorf("HEAD request failed: %v\n", err)
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(headResp.Body)
+
+	if headResp.StatusCode != http.StatusOK {
+		return modifiedAt, fmt.Errorf("Unexpected HEAD response: %s\n", headResp.Status)
+	}
+
+	modifiedAt = headResp.Header.Get("Last-Modified")
+	return modifiedAt, nil
+}


### PR DESCRIPTION
## Why it’s needed
This code separates the logic of receiving weather information into a separate service. This simplifies the main logic of the work.

## What was done
1. Added a new interface for the weather service.
2. The logic for receiving weather information has been moved to a separate service.
3. Added weather chart update even if the date has not changed.