### PR TITLE
Add new text for start and end of work messages

### DIFF
--- a/internal/infrastructure/notify_service.go
+++ b/internal/infrastructure/notify_service.go
@@ -27,12 +27,12 @@ Update At: %s
 `
 
 var startMassageTemplate = `
-Start monitoring the weather.
+Starting a weather watch.
 Nautical twilight today from *%s* to *%s*.
 `
 
 var endMassageTemplate = `
-End of weather monitoring.
+Finishing a weather watch.
 `
 
 type telegramNotifyService struct {


### PR DESCRIPTION
## Why it’s needed
More harmonious texts in the messages of the beginning and end of work.

## What was done
1. Add new text for start and end of work messages.